### PR TITLE
Fix task creation dispatch and expose helper

### DIFF
--- a/api/recurrence.py
+++ b/api/recurrence.py
@@ -28,6 +28,30 @@ def parse_rrule(rrule_str: str, start_date: date) -> Optional[rrulestr]:
     except ValueError:
         return None
 
+def generate_assignments(
+    task: Task,
+    start_date: date,
+    end_date: date,
+    session: Session,
+) -> List[Assignment]:
+    """Generate assignments for a task over a date range.
+
+    This is a thin wrapper around :py:meth:`Task.generate_assignments` used by
+    the test suite. It delegates the actual generation logic to the model
+    method so that tests can import a single helper from ``api.recurrence``.
+
+    Args:
+        task: The task to generate assignments for.
+        start_date: The first date to consider when generating assignments.
+        end_date: The last date to consider when generating assignments.
+        session: Database session for persisting assignments.
+
+    Returns:
+        A list of generated ``Assignment`` objects.
+    """
+
+    return task.generate_assignments(start_date, end_date, session)
+
 def extend_assignment_horizon(
     session: Session,
     horizon_weeks: int = DEFAULT_HORIZON_WEEKS

--- a/src/components/TaskModals/TaskCreationModal.tsx
+++ b/src/components/TaskModals/TaskCreationModal.tsx
@@ -154,7 +154,8 @@ const TaskCreationModal: React.FC<TaskCreationModalProps> = ({ open, onClose, on
       };
 
       const result = await createTask(apiData); // Always call createTask
-      dispatch(addTask(result.task));
+      // The API returns the created task directly, so dispatch that object
+      dispatch(addTask(result));
       onSubmit(result);
       onClose();
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- ensure the new task returned by `createTask` is dispatched
- expose a `generate_assignments` helper in the recurrence module for tests

## Testing
- `pytest -q` *(fails: many tests expecting different API responses)*
- `npm test` *(fails: missing jsdom for vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68621cc14354832b8b3bfcab9a03e06a