### PR TITLE
Fix key API issues

### DIFF
--- a/api/models/absence.py
+++ b/api/models/absence.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, Integer, String, DateTime, Date, ForeignKey, func
 from sqlalchemy.orm import relationship
 from typing import List
 from .base import Base, absence_assignments
+from .assignment import Assignment
 
 class Absence(Base):
     __tablename__ = 'absences'

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -4,8 +4,12 @@ import logging
 
 # Import all route resources
 from .aide_routes import (
-    TeacherAideListResource, 
+    TeacherAideListResource,
     TeacherAideResource
+)
+from .availability_routes import (
+    AvailabilityListResource,
+    AvailabilityResource
 )
 from .task_routes import TaskListResource, TaskResource
 from .assignment_routes import (
@@ -32,8 +36,10 @@ def error_response(code: str, message: str, status: int) -> tuple[dict, int]:
     return {'error': {'code': code, 'message': message}}, status
 
 # Register all resources
-api.add_resource(TeacherAideListResource, '/aides')
-api.add_resource(TeacherAideResource, '/aides/<int:aide_id>')
+api.add_resource(TeacherAideListResource, '/teacher-aides')
+api.add_resource(TeacherAideResource, '/teacher-aides/<int:aide_id>')
+api.add_resource(AvailabilityListResource, '/teacher-aides/<int:aide_id>/availability')
+api.add_resource(AvailabilityResource, '/teacher-aides/<int:aide_id>/availability/<int:avail_id>')
 
 api.add_resource(TaskListResource, '/tasks')
 api.add_resource(TaskResource, '/tasks/<int:task_id>')

--- a/api/routes/task_routes.py
+++ b/api/routes/task_routes.py
@@ -40,7 +40,7 @@ class TaskListResource(Resource):
                 .all()
             
             return {
-                'items': [serialize_task(task) for task in tasks],
+                'tasks': [serialize_task(task) for task in tasks],
                 'total': total,
                 'page': page,
                 'per_page': per_page,
@@ -98,8 +98,8 @@ class TaskListResource(Resource):
             
             session.add(task)
             session.commit()
-            
-            return serialize_task(task), 201
+
+            return {'task': serialize_task(task)}, 201
         except Exception as e:
             session.rollback()
             return error_response('INTERNAL_ERROR', str(e), 500)
@@ -114,7 +114,7 @@ class TaskResource(Resource):
             ).get(task_id)
             if not task:
                 return error_response('NOT_FOUND', f'Task {task_id} not found', 404)
-            return serialize_task(task), 200
+            return {'task': serialize_task(task)}, 200
         except Exception as e:
             return error_response('INTERNAL_ERROR', str(e), 500)
 
@@ -185,11 +185,11 @@ class TaskResource(Resource):
                 )
             
             session.commit()
-            
-            response = serialize_task(task)
+
+            response = {'task': serialize_task(task)}
             if assignments_updated > 0:
                 response['assignments_updated'] = assignments_updated
-            
+
             return response, 200
         except Exception as e:
             session.rollback()


### PR DESCRIPTION
## Summary
- expose teacher aide endpoints and availability under `/api/teacher-aides`
- return consistent task response payloads with `task` and `tasks` wrappers
- import Assignment in Absence model to avoid runtime errors releasing assignments

## Testing
- `pytest` *(fails: KeyError/TypeError and other errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f2aba004832ba6f228f733768ec6